### PR TITLE
Fix missing playground script

### DIFF
--- a/webdev-playground/script.js
+++ b/webdev-playground/script.js
@@ -1,0 +1,5 @@
+// Script for WebDev Playground
+// Log a message when page loads
+window.addEventListener('DOMContentLoaded', function() {
+  console.log('WebDev Playground loaded');
+});


### PR DESCRIPTION
## Summary
- add missing `script.js` for the WebDev Playground sample page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686de1503748832a937773de2801d0d7